### PR TITLE
Add GitHub workflow rules and dev skills (plan-issue, review-respond, fix-ci, investigate)

### DIFF
--- a/dot_claude/rules/github-workflow.md
+++ b/dot_claude/rules/github-workflow.md
@@ -1,0 +1,61 @@
+# GitHub Workflow
+
+Rules for GitHub Issue / PR integration. See `rules/jj-practice.md` for jj operation details.
+
+## Starting Work from an Issue
+
+1. Run `gh issue view <number>` to understand the Issue
+2. Name the bookmark `issue-<number>-<short-description>` (e.g., `issue-123-add-redirect`)
+3. Create a draft PR after implementation is complete
+
+## PR Creation
+
+- Always create as draft with `gh pr create --draft`
+- Only the user marks PRs as ready (Claude must never run `gh pr ready`)
+
+### Title
+
+- Match the Issue title (adjust for brevity if needed)
+- No prefix needed (use GitHub Labels for categorization)
+
+### Body
+
+```markdown
+## Summary
+- Summary of changes (1-3 bullet points)
+
+## Test plan
+- [ ] Test items
+
+Closes #<Issue number>
+```
+
+- Use `Closes #XXX` to auto-close the Issue
+- Use `Relates to #XXX` when related to multiple Issues without auto-close
+
+## Linking PRs to Issues
+
+- `Closes #XXX` in the PR body auto-links the Issue
+- When auto-close is not desired, use `gh pr edit <number> --add-issue <issue-number>` to link via the Development field
+
+## Responding to Review Comments
+
+1. Fetch unresolved comments with `gh api repos/{owner}/{repo}/pulls/<number>/comments`
+2. Present the response plan to the user before starting fixes
+3. Separate commits by comment or by file
+4. After pushing, reply to the review thread (only after user confirmation)
+
+## Rebasing onto master
+
+```bash
+jj git fetch
+jj rebase -d main
+# Resolve conflicts if any
+jj git push --bookmark <bookmark-name>
+```
+
+## Never Do
+
+- Start implementing without reading the Issue
+- Run `gh pr ready` (only the user does this)
+- Address review comments without user approval

--- a/dot_claude/rules/jj-practice.md
+++ b/dot_claude/rules/jj-practice.md
@@ -29,14 +29,20 @@ jj squash          # Merge into child
 
 ## GitHub PR Workflow
 
+### Bookmark Naming Convention
+
+- Issue-driven: `issue-<number>-<short-description>` (e.g., `issue-123-add-redirect`)
+- Without Issue: `<type>/<short-description>` (e.g., `fix/null-pointer`, `chore/update-deps`)
+- Always use kebab-case, no non-ASCII characters
+
 ### Create bookmark and push
 
 ```bash
 # Option 1: Auto-generated name (push-xxxx)
 jj git push -c @-
 
-# Option 2: Explicit naming
-jj bookmark create feature-name -r @-
+# Option 2: Explicit naming (recommended)
+jj bookmark create issue-123-add-redirect -r @-
 jj git push
 ```
 

--- a/dot_claude/skills/fix-ci/SKILL.md
+++ b/dot_claude/skills/fix-ci/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: fix-ci
+description: Analyze and fix GitHub Actions CI errors. Use when the user says "CI is failing", "fix the GitHub Actions error", or "fix CI on PR #XXX".
+---
+
+# Fix CI
+
+Fetch GitHub Actions CI error logs, identify the root cause, and apply fixes.
+
+## Arguments
+
+- `<pr-number or actions-url>` (required): PR number with failing checks, or a GitHub Actions run URL
+
+## Workflow
+
+### Phase 1: Fetch Error Logs
+
+For a PR number:
+```bash
+gh pr checks <number>
+gh run view <run-id> --log-failed
+```
+
+For an Actions URL:
+```bash
+gh run view <run-id> --log-failed
+```
+
+1. Identify the failed job and step
+2. Extract the relevant portion of the error log
+
+### Phase 2: Root Cause Analysis
+
+Classify the error:
+
+| Category | Examples | Response Pattern |
+|----------|----------|-----------------|
+| Compile error | Type errors, missing imports | Fix the code |
+| Test failure | Assertion failure | Fix the test or implementation |
+| Lint/Format | golangci-lint, prettier | Run the formatter |
+| Dependencies | go.sum mismatch, lockfile | Run dependency update commands |
+| Environment/Config | CI config mistake, permissions | Consult the user |
+| Flaky | Timeout, external dependency | Report to the user |
+
+### Phase 3: Fix
+
+1. Report the cause and proposed fix to the user
+2. Code-related errors: create a fix commit
+3. Environment/Flaky errors: propose a plan (do not auto-fix)
+4. Push and re-trigger CI
+
+### Phase 4: Verify
+
+1. Check CI results with `gh pr checks <number>`
+2. If still failing, loop back to Phase 1 (max 3 iterations)
+3. After 3 attempts without resolution, report status and ask the user for direction
+
+## Principles
+
+- **Never auto-fix environment/config errors — consult the user**
+- Do not enter retry loops for flaky tests (report the cause instead)
+- Changes to CI config files (`.github/workflows/`) require user approval
+- Prefix fix commit messages with `fix(ci):`

--- a/dot_claude/skills/investigate/SKILL.md
+++ b/dot_claude/skills/investigate/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: investigate
+description: Investigate a technical topic and compile improvement proposals. Create GitHub Issues after approval. Use when the user says "investigate XXX", "look into this", or "propose improvements for".
+---
+
+# Investigate
+
+Investigate a technical topic or codebase concern, compile structured proposals, and create GitHub Issues after user approval.
+
+## Arguments
+
+- `<topic>` (required): The technical topic or concern to investigate
+- `--create-issue`: Proceed to Issue creation after investigation
+
+## Workflow
+
+### Phase 1: Scope Confirmation
+
+1. Confirm the investigation scope with the user:
+   - What do they want to learn or improve?
+   - Depth: overview or detailed analysis?
+   - Constraints: timeline, compatibility, dependencies
+
+### Phase 2: Investigation
+
+Use Agents for parallel investigation:
+
+1. **Codebase analysis**: Identify related code, understand current implementation
+2. **External references**: Consult documentation and best practices as needed
+3. **Impact assessment**: Check change impact with `findReferences` etc.
+
+### Phase 3: Investigation Report
+
+Present findings in this structure:
+
+```markdown
+## Investigation Report: <topic>
+
+### Current State
+- <summary of current implementation/state>
+
+### Issues / Improvement Opportunities
+1. <issue>: <impact/risk>
+2. ...
+
+### Proposals
+| # | Proposal | Benefit | Effort | Risk |
+|---|----------|---------|--------|------|
+| 1 | ... | ... | S/M/L | ... |
+
+### Recommended Approach
+- <most recommended path forward>
+
+### Next Steps
+- [ ] Create Issue(s)
+- [ ] Draft implementation plan
+```
+
+### Phase 4: Issue Creation (after user approval)
+
+1. Create Issue(s) with `gh issue create`
+2. Assign appropriate labels and milestones
+3. If the work should be split into multiple Issues, suggest that
+
+## Principles
+
+- **Always present findings and get user approval before taking further action**
+- Issue creation requires explicit user approval
+- Follow `rules/security.md` protocol for any security issues discovered
+- Explicitly label speculation and hypotheses ("Hypothesis:", "Needs verification:")

--- a/dot_claude/skills/plan-issue/SKILL.md
+++ b/dot_claude/skills/plan-issue/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: plan-issue
+description: Create an implementation plan from a GitHub Issue and start work. Runs the full Issue-driven development workflow end-to-end. Use when the user says "work on Issue #XXX", "plan #XXX", or "implement this Issue".
+---
+
+# Plan Issue
+
+Run the full workflow from a GitHub Issue: investigate, plan, and start implementation.
+
+## Arguments
+
+- `<issue-number>` (required): GitHub Issue number (e.g., `123`, `#123`)
+- `--start`: After plan approval, proceed to set up the work environment (create bookmark, begin implementation)
+
+## Workflow
+
+### Phase 1: Understand the Issue
+
+1. Fetch Issue content with `gh issue view <number>`
+2. Check labels, milestone, and related Issues
+3. Extract requirements, constraints, and acceptance criteria
+
+### Phase 2: Codebase Investigation
+
+1. Identify code related to the Issue (use Agents for parallel investigation)
+   - Files and functions to be changed
+   - Dependent code affected (`findReferences`)
+   - Existing test coverage and scope
+2. Report findings to the user concisely
+
+### Phase 3: Implementation Plan
+
+Create and present the plan in this structure:
+
+```markdown
+# Implementation Plan: <Issue title>
+
+## Context
+- Issue: #<number>
+- Goal: <one line>
+
+## Tasks
+- [ ] Task 1: <specific change>
+  - File: `path/to/file`
+  - Change summary: ...
+- [ ] Task 2: ...
+
+## Risks / Open Questions
+- <risks or unknowns>
+
+## Test Strategy
+- <testing approach>
+```
+
+### Phase 4: Start Work (`--start` or after user approval)
+
+1. Create bookmark: `issue-<number>-<short-description>`
+2. Begin TDD implementation starting from Task 1
+3. Commit per task (`jj describe` then `jj new`)
+
+## Principles
+
+- **Get user approval before moving from plan to implementation** (always confirm at Phase 3)
+- If investigation reveals significant deviation from the Issue's assumptions, suggest commenting on the Issue
+- Plan granularity should map to commits (1 Task ≈ 1 commit)
+- Follow `rules/github-workflow.md` for naming and PR creation
+- Follow `rules/testing.md` for TDD principles

--- a/dot_claude/skills/review-respond/SKILL.md
+++ b/dot_claude/skills/review-respond/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: review-respond
+description: Fetch PR review comments and propose/implement responses. Use when the user says "address review comments", "respond to PR #XXX review", or "handle review feedback".
+---
+
+# Review Respond
+
+Fetch review comments on a PR, propose a response plan for unresolved comments, then implement fixes after user approval.
+
+## Arguments
+
+- `<pr-number>` (required): Pull Request number
+
+## Workflow
+
+### Phase 1: Collect Comments
+
+1. Get PR repo info (`gh pr view <number> --json url,headRefName`)
+2. Fetch review comments:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<number>/reviews
+   gh api repos/{owner}/{repo}/pulls/<number>/comments
+   ```
+3. Extract and categorize unresolved comments
+
+### Phase 2: Present Response Plan
+
+Present each comment to the user in this format:
+
+```markdown
+## Review Comment Response Plan
+
+### 1. <comment summary> (@reviewer)
+> <original comment quote>
+
+**Target**: `path/to/file:line`
+**Plan**: <proposed response, concisely>
+**Effort**: S / M / L
+
+### 2. ...
+```
+
+- Add rationale for comments deemed no-action-needed
+- Offer multiple options for ambiguous comments
+
+### Phase 3: Implement (after user approval)
+
+1. Move to the PR's bookmark in `jj`
+2. Separate commits by comment or by file
+3. Include the addressed comment in each commit message
+   - e.g., `fix: address review comment - validate input before processing`
+4. Push with `jj git push --bookmark <bookmark-name>`
+
+### Phase 4: Reply Drafts (optional)
+
+After pushing, present draft reply text for each comment.
+Never post replies on GitHub without explicit user confirmation.
+
+## Principles
+
+- **Present the full response plan before starting any fixes**
+- Ask the user for clarification when reviewer intent is unclear
+- Keep commit granularity traceable to individual comments
+- Posting replies on GitHub requires explicit user approval


### PR DESCRIPTION
## Summary
- Add `rules/github-workflow.md` for Issue/PR integration conventions (draft PR, Closes syntax, review comment handling)
- Add bookmark naming convention to `rules/jj-practice.md`
- Add 4 new skills: `plan-issue`, `review-respond`, `fix-ci`, `investigate`

## Test plan
- [x] `chezmoi apply` and verify files are deployed to `~/.claude/`
- [x] Test each skill in a real project session