### PR TITLE
Improve zsh prompt and add mysql-client PATH

### DIFF
--- a/dot_zsh/tool.rc.zsh
+++ b/dot_zsh/tool.rc.zsh
@@ -60,3 +60,11 @@ fi
 if command -v pack &>/dev/null; then
   source "$(pack completion --shell zsh)"
 fi
+
+# homebrew packages
+if command -v brew &>/dev/null; then
+  local brew_prefix="$(brew --prefix)"
+  if [[ -d "$brew_prefix/opt/mysql-client/bin" ]]; then
+    export PATH="$brew_prefix/opt/mysql-client/bin:$PATH"
+  fi
+fi

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -38,5 +38,5 @@ prompt_lime_render() {
   echo -n ' '
   prompt_lime_git
   echo -n $'\n'
-  echo -n "${prompt_lime_rendered_symbol} "
+  echo -n "${prompt_lime_rendered_symbol}"
 }


### PR DESCRIPTION
## Summary
- プロンプトシンボル後の余分な末尾スペースを削除
- tool.rc.zsh に mysql-client の PATH 設定を追加（`brew --prefix` で動的取得）

## Test plan
- [x] zsh でプロンプト表示が正常であることを確認
- [x] `which mysql` で mysql-client が見つかることを確認