### PR TITLE
Add @github/copilot npm package to mise

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -34,6 +34,7 @@ jq = "latest"
 mkcert = "latest"
 node = ["20", "lts"]
 "npm:@anthropic-ai/claude-code" = "latest"
+"npm:@github/copilot" = "latest"
 "npm:@openai/codex" = "latest"
 "npm:@ralph-orchestrator/ralph-cli" = "latest"
 "npm:agent-browser" = "latest"


### PR DESCRIPTION
## Summary
- miseの設定に `@github/copilot` npmパッケージを追加

## Test plan
- [x] `chezmoi apply` で設定が反映されること
- [x] `mise install` で `@github/copilot` がインストールされること